### PR TITLE
Convert thumbnail url to base image url

### DIFF
--- a/src/StreamWrapper/LocalDevPublicStream.php
+++ b/src/StreamWrapper/LocalDevPublicStream.php
@@ -94,6 +94,7 @@ class LocalDevPublicStream extends PublicStream {
    */
   private function fetchFromRemoteInstance($uri) {
     $localPath = $this->getDirectoryPath() . '/' . $this->getTarget($uri);
+    $localPath = preg_replace('/styles\/.*?\/public\//', '', $localPath);
     $remotePath = realpath($localPath) ?
       FALSE :
       $this->remoteInstance . '/' . UrlHelper::encodePath($localPath);


### PR DESCRIPTION
**Problem**
At the moment, any requests to non-existing files are mapped to the live environment. When uploading an image locally, the thumbnails are only generated on request, so they don't exist, even if the source image is local. Hence, the url is rewritten to point to the remote environment and prevents thumbnails of local images from being generated and shown.

**Proposal**
This PR adds a regex conversion from requests to a thumbnail uri to the source image uri. 
If the source image exists, the request is dealt by core PublicStreamWrapper, resulting in thumbnails being generating.

**Open question**
- Can we assume only thumbnail URIs to have this pattern? 
- Is there a better way to deal with this situation?
