### PR TITLE
Allow config overrides by creating a default config object on installation

### DIFF
--- a/iq_stage_file_proxy.install
+++ b/iq_stage_file_proxy.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Contains iq_stage_file_proxy.install.
+ */
+
+/**
+ * Set default config on install.
+ */
+function iq_stage_file_proxy_install() {
+  $config = \Drupal::configFactory()->getEditable('iq_stage_file_proxy.settings');
+  $config->set('remote_instance', NULL)->set('offload', FALSE)->save();
+}

--- a/src/EventSubscriber/KernelRequestSubscriber.php
+++ b/src/EventSubscriber/KernelRequestSubscriber.php
@@ -3,10 +3,10 @@
 namespace Drupal\iq_stage_file_proxy\EventSubscriber;
 
 use Drupal\Core\File\FileUrlGeneratorInterface;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**


### PR DESCRIPTION
Create a default config object on installation to allow overrides from *.settings.php to take effect even with domain_config installed.