### PR TITLE
DGI-3685: Add missing config schema

### DIFF
--- a/config/schema/iq_stage_file_proxy.schema.yml
+++ b/config/schema/iq_stage_file_proxy.schema.yml
@@ -1,0 +1,11 @@
+iq_stage_file_proxy.settings:
+  type: config_object
+  label: 'IQ Stage File Proxy settings'
+  mapping:
+    remote_instance:
+      type: string
+      label: 'Remote instance'
+      nullable: true
+    offload:
+      type: boolean
+      label: 'Offload'


### PR DESCRIPTION
On Drupal 11 a validation throws warnings about missing config schemas for this module.
They've been added in this PR